### PR TITLE
Fix NPE race condition in placeholders

### DIFF
--- a/src/main/java/org/lushplugins/lushrewards/module/dailyrewards/DailyRewardsPlaceholder.java
+++ b/src/main/java/org/lushplugins/lushrewards/module/dailyrewards/DailyRewardsPlaceholder.java
@@ -43,6 +43,9 @@ public class DailyRewardsPlaceholder {
             Optional<Module> optionalModule = LushRewards.getInstance().getModule(params[0]);
             if (optionalModule.isPresent() && optionalModule.get() instanceof DailyRewardsModule module) {
                 DailyRewardsModule.UserData userData = module.getUserData(player.getUniqueId());
+                if (userData == null) {
+                    return "false";
+                }
                 return String.valueOf(userData.hasCollectedToday());
             } else {
                 return null;
@@ -56,6 +59,9 @@ public class DailyRewardsPlaceholder {
             Optional<Module> optionalModule = LushRewards.getInstance().getModule(params[0]);
             if (optionalModule.isPresent() && optionalModule.get() instanceof DailyRewardsModule module) {
                 DailyRewardsModule.UserData userData = module.getUserData(player.getUniqueId());
+                if (userData == null) {
+                    return "0";
+                }
                 return String.valueOf(userData.getDayNum());
             } else {
                 return null;
@@ -69,6 +75,9 @@ public class DailyRewardsPlaceholder {
             Optional<Module> optionalModule = LushRewards.getInstance().getModule(params[0]);
             if (optionalModule.isPresent() && optionalModule.get() instanceof DailyRewardsModule module) {
                 DailyRewardsModule.UserData userData = module.getUserData(player.getUniqueId());
+                if (userData == null) {
+                    return "0";
+                }
                 return String.valueOf(userData.getHighestStreak());
             } else {
                 return "0";
@@ -82,6 +91,9 @@ public class DailyRewardsPlaceholder {
             Optional<Module> optionalModule = LushRewards.getInstance().getModule(params[0]);
             if (optionalModule.isPresent() && optionalModule.get() instanceof DailyRewardsModule module) {
                 DailyRewardsModule.UserData userData = module.getUserData(player.getUniqueId());
+                if (userData == null) {
+                    return "0";
+                }
                 return String.valueOf(userData.getStreak());
             } else {
                 return "0";
@@ -95,6 +107,9 @@ public class DailyRewardsPlaceholder {
             Optional<Module> optionalModule = LushRewards.getInstance().getModule(params[0]);
             if (optionalModule.isPresent() && optionalModule.get() instanceof DailyRewardsModule module) {
                 DailyRewardsModule.UserData userData = module.getUserData(player.getUniqueId());
+                if (userData == null) {
+                    return "0";
+                }
                 RewardDay rewardDay = module.getRewardDay(LocalDate.now(), userData.getStreak());
                 return String.valueOf(rewardDay.getRewardCount());
             } else {
@@ -105,6 +120,9 @@ public class DailyRewardsPlaceholder {
             Optional<Module> optionalModule = LushRewards.getInstance().getModule(params[0]);
             if (optionalModule.isPresent() && optionalModule.get() instanceof DailyRewardsModule module) {
                 DailyRewardsModule.UserData userData = module.getUserData(player.getUniqueId());
+                if (userData == null) {
+                    return null;
+                }
 
                 int dayNum = Integer.parseInt(params[2]);
                 LocalDate date = userData.getExpectedDateOnDayNum(dayNum);


### PR DESCRIPTION
This commit addresses a Race Condition where plugins like TAB / TAB-Bridge or ajLeaderboards request LushRewards placeholders before the player's data is fully loaded, causing a NullPointerException.

Fix details:
- Added null checks for 'userData' in all placeholder callbacks in DailyRewardsPlaceholder.java.
- Placeholders now safely return default values ('0', 'false', or null) instead of throwing an NPE when data is missing.

This ensures server stability during player join events.