### PR TITLE
Fix auto claim issues for playtime rewards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.gradle/
+.idea/
+build/

--- a/src/main/java/org/lushplugins/lushrewards/module/playtimerewards/PlaytimeRewardsModule.java
+++ b/src/main/java/org/lushplugins/lushrewards/module/playtimerewards/PlaytimeRewardsModule.java
@@ -221,10 +221,10 @@ public class PlaytimeRewardsModule extends RewardModule implements UserDataModul
         }
 
         ChatColorHandler.sendMessage(player, rewardMessage
-            .replace("%minutes%", String.valueOf(playtimeSinceLastCollected))
-            .replace("%hours%", String.valueOf((int) Math.floor(playtimeSinceLastCollected / 60D)))
-            .replace("%total_minutes%", String.valueOf(playtime))
-            .replace("%total_hours%", String.valueOf((int) Math.floor(playtime / 60D))));
+            .replace("%minutes%", String.valueOf(playtimeSinceLastCollected - 1))
+            .replace("%hours%", String.valueOf((int) Math.floor((playtimeSinceLastCollected - 1) / 60D)))
+            .replace("%total_minutes%", String.valueOf(playtime - 1))
+            .replace("%total_hours%", String.valueOf((int) Math.floor((playtime - 1) / 60D))));
 
         userData.setLastCollectedPlaytime(globalPlaytime);
         saveUserData(userData);

--- a/src/main/java/org/lushplugins/lushrewards/module/playtimetracker/PlaytimeTracker.java
+++ b/src/main/java/org/lushplugins/lushrewards/module/playtimetracker/PlaytimeTracker.java
@@ -105,15 +105,13 @@ public class PlaytimeTracker {
             }
         }
 
-        if (globalTime % 5 == 0) {
-            RewardUser rewardUser = LushRewards.getInstance().getDataManager().getRewardUser(player);
-            if (rewardUser != null) {
-                rewardUser.setMinutesPlayed(globalTime);
-            } else {
-                Optional<Module> optionalModule = LushRewards.getInstance().getModule(RewardModule.Type.PLAYTIME_TRACKER);
-                if (optionalModule.isPresent() && optionalModule.get() instanceof PlaytimeTrackerModule playtimeTrackerModule) {
-                    playtimeTrackerModule.stopPlaytimeTracker(player.getUniqueId());
-                }
+        RewardUser rewardUser = LushRewards.getInstance().getDataManager().getRewardUser(player);
+        if (rewardUser != null) {
+            rewardUser.setMinutesPlayed(globalTime);
+        } else {
+            Optional<Module> optionalModule = LushRewards.getInstance().getModule(RewardModule.Type.PLAYTIME_TRACKER);
+            if (optionalModule.isPresent() && optionalModule.get() instanceof PlaytimeTrackerModule playtimeTrackerModule) {
+                playtimeTrackerModule.stopPlaytimeTracker(player.getUniqueId());
             }
         }
     }


### PR DESCRIPTION
Fixes 2 issues with the playtime rewards:
- Auto claim check being hardcoded to a 5-minute interval
  - I don't really see the intention behind this code, so I have removed the condition for the interval. Please let me know if there are any good reasons to have this
- Time displayed in the auto claim notification being off by 1

Also adds a gitignore file to prevent accidentally pushing build files